### PR TITLE
SCRUM-107 예약 로직 동시성 제어

### DIFF
--- a/api-user/src/main/java/com/wellmeet/reservation/ReservationService.java
+++ b/api-user/src/main/java/com/wellmeet/reservation/ReservationService.java
@@ -75,7 +75,7 @@ public class ReservationService {
     public void cancel(Long reservationId, Long memberId) {
         Reservation reservation = reservationDomainService.getByIdAndMemberId(reservationId, memberId);
         AvailableDate availableDate = reservation.getAvailableDate();
-        availableDate.increaseCapacity(reservation.getPartySize());
+        restaurantDomainService.increaseAvailableDateCapacity(availableDate, reservation.getPartySize());
         reservation.cancel();
     }
 }

--- a/api-user/src/test/java/com/wellmeet/reservation/ReservationServiceTest.java
+++ b/api-user/src/test/java/com/wellmeet/reservation/ReservationServiceTest.java
@@ -138,7 +138,7 @@ class ReservationServiceTest extends BaseServiceTest {
             AvailableDate foundAvailableDate2 = availableDateRepository.findById(availableDate2.getId()).get();
 
             assertAll(
-                    () -> assertThat(reservations).hasSize(2),
+                    () -> assertThat(reservations).hasSize(1),
                     () -> assertThat(foundAvailableDate1.getMaxCapacity()).isEqualTo(capacity),
                     () -> assertThat(foundAvailableDate2.getMaxCapacity()).isEqualTo(capacity - changePartySize)
             );

--- a/api-user/src/test/java/com/wellmeet/reservation/ReservationServiceTest.java
+++ b/api-user/src/test/java/com/wellmeet/reservation/ReservationServiceTest.java
@@ -81,7 +81,71 @@ class ReservationServiceTest extends BaseServiceTest {
     class UpdateReservation {
 
         @Test
-        void name() throws InterruptedException {
+        void 같은_예약시간의_인원수를_변경할_수_있다() {
+            Owner owner1 = ownerGenerator.generate("owner1");
+            Restaurant restaurant1 = restaurantGenerator.generate("restaurant1", owner1);
+            int capacity = 16;
+            AvailableDate availableDate1 = availableDateGenerator.generate(LocalDateTime.now().plusDays(1), capacity,
+                    restaurant1);
+            int partySize = 4;
+            Member member1 = memberGenerator.generate("member1");
+            CreateReservationRequest createRequest1 = new CreateReservationRequest(
+                    restaurant1.getId(), availableDate1.getId(), partySize, "request"
+            );
+            CreateReservationResponse reserve1 = reservationService.reserve(member1.getId(), createRequest1);
+            int changePartySize = 7;
+            CreateReservationRequest request1 = new CreateReservationRequest(
+                    restaurant1.getId(), availableDate1.getId(), changePartySize, "request"
+            );
+
+            reservationService.updateReservation(
+                    reserve1.getId(), member1.getId(), request1
+            );
+            List<Reservation> reservations = reservationRepository.findAll();
+            AvailableDate foundAvailableDate1 = availableDateRepository.findById(availableDate1.getId()).get();
+
+            assertAll(
+                    () -> assertThat(reservations).hasSize(1),
+                    () -> assertThat(foundAvailableDate1.getMaxCapacity()).isEqualTo(capacity - changePartySize)
+            );
+        }
+
+        @Test
+        void 한_사람이_업데이트_요청을_동시에_여러개_보내도_한_번만_처리된다() throws InterruptedException {
+            Owner owner1 = ownerGenerator.generate("owner1");
+            Restaurant restaurant1 = restaurantGenerator.generate("restaurant1", owner1);
+            int capacity = 50;
+            AvailableDate availableDate1 = availableDateGenerator.generate(LocalDateTime.now().plusDays(1), capacity,
+                    restaurant1);
+            AvailableDate availableDate2 = availableDateGenerator.generate(LocalDateTime.now().plusDays(2), capacity,
+                    restaurant1);
+            int partySize = 4;
+            Member member1 = memberGenerator.generate("member1");
+            CreateReservationRequest createRequest1 = new CreateReservationRequest(
+                    restaurant1.getId(), availableDate1.getId(), partySize, "request"
+            );
+            CreateReservationResponse reserve1 = reservationService.reserve(member1.getId(), createRequest1);
+            int changePartySize = 7;
+            CreateReservationRequest request1 = new CreateReservationRequest(
+                    restaurant1.getId(), availableDate2.getId(), changePartySize, "request"
+            );
+
+            runAtSameTime(10, () -> reservationService.updateReservation(
+                    reserve1.getId(), member1.getId(), request1
+            ));
+            List<Reservation> reservations = reservationRepository.findAll();
+            AvailableDate foundAvailableDate1 = availableDateRepository.findById(availableDate1.getId()).get();
+            AvailableDate foundAvailableDate2 = availableDateRepository.findById(availableDate2.getId()).get();
+
+            assertAll(
+                    () -> assertThat(reservations).hasSize(2),
+                    () -> assertThat(foundAvailableDate1.getMaxCapacity()).isEqualTo(capacity),
+                    () -> assertThat(foundAvailableDate2.getMaxCapacity()).isEqualTo(capacity - changePartySize)
+            );
+        }
+
+        @Test
+        void 여러_사람이_업데이트_요청을_동시에_여러개가_보내도_적절히_처리된다() throws InterruptedException {
             Owner owner1 = ownerGenerator.generate("owner1");
             Restaurant restaurant1 = restaurantGenerator.generate("restaurant1", owner1);
             int capacity = 16;

--- a/api-user/src/test/java/com/wellmeet/reservation/ReservationServiceTest.java
+++ b/api-user/src/test/java/com/wellmeet/reservation/ReservationServiceTest.java
@@ -10,6 +10,7 @@ import com.wellmeet.domain.reservation.entity.Reservation;
 import com.wellmeet.domain.restaurant.availabledate.entity.AvailableDate;
 import com.wellmeet.domain.restaurant.entity.Restaurant;
 import com.wellmeet.reservation.dto.CreateReservationRequest;
+import com.wellmeet.reservation.dto.CreateReservationResponse;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -72,6 +73,61 @@ class ReservationServiceTest extends BaseServiceTest {
             assertAll(
                     () -> assertThat(reservations).hasSize(50),
                     () -> assertThat(foundAvailableDate.getMaxCapacity()).isZero()
+            );
+        }
+    }
+
+    @Nested
+    class UpdateReservation {
+
+        @Test
+        void name() throws InterruptedException {
+            Owner owner1 = ownerGenerator.generate("owner1");
+            Restaurant restaurant1 = restaurantGenerator.generate("restaurant1", owner1);
+            int capacity = 16;
+            AvailableDate availableDate1 = availableDateGenerator.generate(LocalDateTime.now().plusDays(1), capacity,
+                    restaurant1);
+            AvailableDate availableDate2 = availableDateGenerator.generate(LocalDateTime.now().plusDays(2), capacity,
+                    restaurant1);
+            AvailableDate availableDate3 = availableDateGenerator.generate(LocalDateTime.now().plusDays(3), capacity,
+                    restaurant1);
+            int partySize = 4;
+            Member member1 = memberGenerator.generate("member1");
+            Member member2 = memberGenerator.generate("member2");
+            CreateReservationRequest createRequest1 = new CreateReservationRequest(
+                    restaurant1.getId(), availableDate1.getId(), partySize, "request"
+            );
+            CreateReservationRequest createRequest2 = new CreateReservationRequest(
+                    restaurant1.getId(), availableDate2.getId(), partySize, "request"
+            );
+            CreateReservationResponse reserve1 = reservationService.reserve(member1.getId(), createRequest1);
+            CreateReservationResponse reserve2 = reservationService.reserve(member2.getId(), createRequest2);
+            int changePartySize = 7;
+            CreateReservationRequest request1 = new CreateReservationRequest(
+                    restaurant1.getId(), availableDate3.getId(), changePartySize, "request"
+            );
+            CreateReservationRequest request2 = new CreateReservationRequest(
+                    restaurant1.getId(), availableDate3.getId(), changePartySize, "request"
+            );
+            List<Runnable> tasks = new ArrayList<>();
+            tasks.add(() -> reservationService.updateReservation(
+                    reserve1.getId(), member1.getId(), request1
+            ));
+            tasks.add(() -> reservationService.updateReservation(
+                    reserve2.getId(), member2.getId(), request2
+            ));
+
+            runAtSameTime(tasks);
+            List<Reservation> reservations = reservationRepository.findAll();
+            AvailableDate foundAvailableDate1 = availableDateRepository.findById(availableDate1.getId()).get();
+            AvailableDate foundAvailableDate2 = availableDateRepository.findById(availableDate2.getId()).get();
+            AvailableDate foundAvailableDate3 = availableDateRepository.findById(availableDate3.getId()).get();
+
+            assertAll(
+                    () -> assertThat(reservations).hasSize(2),
+                    () -> assertThat(foundAvailableDate1.getMaxCapacity()).isEqualTo(capacity),
+                    () -> assertThat(foundAvailableDate2.getMaxCapacity()).isEqualTo(capacity),
+                    () -> assertThat(foundAvailableDate3.getMaxCapacity()).isEqualTo(capacity - changePartySize * 2)
             );
         }
     }

--- a/domain/src/main/java/com/wellmeet/domain/common/RepositoryErrorDecoder.java
+++ b/domain/src/main/java/com/wellmeet/domain/common/RepositoryErrorDecoder.java
@@ -1,0 +1,23 @@
+package com.wellmeet.domain.common;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+
+public class RepositoryErrorDecoder {
+
+    private static final String UNIQUE_RESERVATION_ERROR_MESSAGE = "unique_member_restaurant_available_date";
+
+    private RepositoryErrorDecoder() {
+    }
+
+    public static boolean isUniqueConstraintViolation(DataIntegrityViolationException exception) {
+        Throwable cause = exception.getCause();
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException cve) {
+                return UNIQUE_RESERVATION_ERROR_MESSAGE.equals(cve.getConstraintName());
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+}

--- a/domain/src/main/java/com/wellmeet/domain/reservation/ReservationDomainService.java
+++ b/domain/src/main/java/com/wellmeet/domain/reservation/ReservationDomainService.java
@@ -1,11 +1,13 @@
 package com.wellmeet.domain.reservation;
 
+import com.wellmeet.domain.common.RepositoryErrorDecoder;
 import com.wellmeet.domain.reservation.entity.Reservation;
 import com.wellmeet.domain.reservation.exception.ReservationErrorCode;
 import com.wellmeet.domain.reservation.exception.ReservationException;
 import com.wellmeet.domain.reservation.repository.ReservationRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,7 +17,14 @@ public class ReservationDomainService {
     private final ReservationRepository reservationRepository;
 
     public Reservation save(Reservation reservation) {
-        return reservationRepository.save(reservation);
+        try {
+            return reservationRepository.save(reservation);
+        } catch (DataIntegrityViolationException exception) {
+            if (RepositoryErrorDecoder.isUniqueConstraintViolation(exception)) {
+                throw new ReservationException(ReservationErrorCode.ALREADY_RESERVED);
+            }
+            throw exception;
+        }
     }
 
     public Reservation getByIdAndMemberId(Long reservationId, Long memberId) {

--- a/domain/src/main/java/com/wellmeet/domain/reservation/entity/Reservation.java
+++ b/domain/src/main/java/com/wellmeet/domain/reservation/entity/Reservation.java
@@ -13,12 +13,21 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Table(
+        name = "reservation",
+        uniqueConstraints = @UniqueConstraint(
+                name = "unique_member_restaurant_available_date",
+                columnNames = {"member_id", "restaurant_id", "available_date_id"}
+        )
+)
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/domain/src/main/java/com/wellmeet/domain/restaurant/availabledate/entity/AvailableDate.java
+++ b/domain/src/main/java/com/wellmeet/domain/restaurant/availabledate/entity/AvailableDate.java
@@ -52,9 +52,4 @@ public class AvailableDate extends BaseEntity {
     public boolean canNotReserve(int partySize) {
         return !isAvailable || maxCapacity < partySize;
     }
-
-    public void increaseCapacity(int partySize) {
-        maxCapacity += partySize;
-        isAvailable = true;
-    }
 }

--- a/domain/src/main/java/com/wellmeet/domain/restaurant/availabledate/repository/AvailableDateRepository.java
+++ b/domain/src/main/java/com/wellmeet/domain/restaurant/availabledate/repository/AvailableDateRepository.java
@@ -1,11 +1,9 @@
 package com.wellmeet.domain.restaurant.availabledate.repository;
 
 import com.wellmeet.domain.restaurant.availabledate.entity.AvailableDate;
-import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,7 +14,6 @@ public interface AvailableDateRepository extends JpaRepository<AvailableDate, Lo
 
     List<AvailableDate> findAllByRestaurantId(String restaurantId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<AvailableDate> findByIdAndRestaurantId(Long id, String restaurantId);
 
     @Modifying

--- a/domain/src/main/java/com/wellmeet/domain/restaurant/availabledate/repository/AvailableDateRepository.java
+++ b/domain/src/main/java/com/wellmeet/domain/restaurant/availabledate/repository/AvailableDateRepository.java
@@ -1,9 +1,11 @@
 package com.wellmeet.domain.restaurant.availabledate.repository;
 
 import com.wellmeet.domain.restaurant.availabledate.entity.AvailableDate;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +16,7 @@ public interface AvailableDateRepository extends JpaRepository<AvailableDate, Lo
 
     List<AvailableDate> findAllByRestaurantId(String restaurantId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<AvailableDate> findByIdAndRestaurantId(Long id, String restaurantId);
 
     @Modifying

--- a/domain/src/main/resources/schema.sql
+++ b/domain/src/main/resources/schema.sql
@@ -78,6 +78,7 @@ CREATE TABLE IF NOT EXISTS reservation
     FOREIGN KEY (restaurant_id) REFERENCES restaurant (id),
     FOREIGN KEY (available_date_id) REFERENCES available_date (id),
     FOREIGN KEY (member_id) REFERENCES member (id),
+    UNIQUE KEY unique_member_restaurant_available_date (member_id, restaurant_id, available_date_id),
     CHECK (status IN ('PENDING', 'CONFIRMED', 'CANCELED')),
     INDEX idx_reservation_restaurant (restaurant_id),
     INDEX idx_reservation_member (member_id),

--- a/domain/src/test/java/com/wellmeet/domain/restaurant/availabledate/entity/AvailableDateTest.java
+++ b/domain/src/test/java/com/wellmeet/domain/restaurant/availabledate/entity/AvailableDateTest.java
@@ -1,11 +1,7 @@
 package com.wellmeet.domain.restaurant.availabledate.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.wellmeet.domain.restaurant.exception.RestaurantErrorCode;
-import com.wellmeet.domain.restaurant.exception.RestaurantException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import org.junit.jupiter.api.Nested;
@@ -14,57 +10,21 @@ import org.junit.jupiter.api.Test;
 class AvailableDateTest {
 
     @Nested
-    class ReserveParty {
+    class CanNotReserve {
 
         @Test
-        void 예약_인원만큼_가용_인원이_줄어든다() {
+        void 예약_인원수가_가용인원보다_크면_예약이_불가능하다() {
             int maxCapacity = 10;
             AvailableDate availableDate = new AvailableDate(
-                    LocalDate.now().plusDays(1),
+                    LocalDate.now(),
                     LocalTime.now(),
                     maxCapacity,
                     null
             );
-            int partySize = 5;
-            availableDate.reduceCapacity(partySize);
+            int partySize = maxCapacity + 1;
+            boolean canNotReserve = availableDate.canNotReserve(partySize);
 
-            assertAll(
-                    () -> assertThat(availableDate.getMaxCapacity()).isEqualTo(maxCapacity - partySize),
-                    () -> assertThat(availableDate.isAvailable()).isTrue()
-            );
-        }
-
-        @Test
-        void 가용_인원이_0이면_예약_불가능하다() {
-            int maxCapacity = 10;
-            AvailableDate availableDate = new AvailableDate(
-                    LocalDate.now().plusDays(1),
-                    LocalTime.now(),
-                    maxCapacity,
-                    null
-            );
-            int partySize = 10;
-            availableDate.reduceCapacity(partySize);
-
-            assertAll(
-                    () -> assertThat(availableDate.getMaxCapacity()).isEqualTo(maxCapacity - partySize),
-                    () -> assertThat(availableDate.isAvailable()).isFalse()
-            );
-        }
-
-        @Test
-        void 가용_인원_수보다_많은_인원이_예약할_수_없다() {
-            int maxCapacity = 10;
-            AvailableDate availableDate = new AvailableDate(
-                    LocalDate.now().plusDays(1),
-                    LocalTime.now(),
-                    maxCapacity,
-                    null
-            );
-
-            assertThatThrownBy(() -> availableDate.reduceCapacity(maxCapacity + 1))
-                    .isInstanceOf(RestaurantException.class)
-                    .hasMessage(RestaurantErrorCode.NOT_ENOUGH_CAPACITY.getMessage());
+            assertThat(canNotReserve).isTrue();
         }
     }
 }


### PR DESCRIPTION
# 🚩 Jira Ticket
[SCRUM-107]

# 🗣️ 리뷰 요구사항 (선택)
인덱스키를 활용하여 동시성을 제어했습니다. 다만 아래의 고민점으로 Redis 분산락이나 Named Lock을 활용하도록 리팩토링할까 고민중입니다.

1. 
```
    @Modifying
    @Query("update AvailableDate a "
            + "set a.maxCapacity = a.maxCapacity - :partySize, "
            + "a.isAvailable = case when (a.maxCapacity - :partySize) = 0 then false else a.isAvailable end "
            + "where a.id = :id and a.maxCapacity >= :partySize")
    int decreaseCapacity(@Param("id") Long id, @Param("partySize") int partySize);
```
```
public void decreaseCapacity(AvailableDate availableDate, int partySize) {
        int row = availableDateRepository.decreaseCapacity(availableDate.getId(), partySize);
        if (row == 0) {
            throw new RestaurantException(RestaurantErrorCode.NOT_ENOUGH_CAPACITY);
        }
    }
```

예약이 가능한 지 확인하는 방법을 Repository에서 반환한 int 값을 이용해 만약 변경된 Row가 없어서 0을 반환했다는 것은 where 조건에서 `a.maxCapacity >= :partySize`를 만족하지 못한 것이라 판단하고 예외 처리를 하고 있습니다. 다만 무조건 이 경우밖에 없다고 단정짓지 못 하기에 제대로 검증하기 위해선 추가적인 절차가 필요하다고 판단했습니다.

---

2.
DB의 save에서 예외가 발생했을 때 이 예외가 Unique로 인한 조건인지 다른 문제로 인한 것인지 파악하는 로직을 추가해야 하는데 이 부분을 예외 메시지에 Unique 키가 포함되어 있을 때 따로 처리하거나, MySQL의 Unique 오류 예외 코드를 통해 따로 처리하거나 해야되는데 이 방법이 좋은 방법인지 의문점이 듭니다.

[SCRUM-107]: https://soft-macaron.atlassian.net/browse/SCRUM-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 동일 회원이 같은 식당과 예약 가능한 날짜에 중복 예약을 할 수 없도록 고유 제약 조건이 추가되었습니다.

* **테스트**
  * 예약 업데이트 기능에 대한 동시성 시나리오 테스트가 추가되었습니다.
  * 예약 가능 인원 검증 테스트가 간소화되었습니다.

* **새로운 기능**
  * 데이터베이스 고유 제약 위반을 감지하는 유틸리티가 추가되었습니다.

* **리팩터**
  * 예약 취소 시 용량 증가 처리가 도메인 서비스로 이동되었습니다.
  * 예외 처리 로직이 도메인 예외로 변환되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->